### PR TITLE
feat: enhance message input and list components with mobile responsiveness

### DIFF
--- a/src/frontend/components/message-input.tsx
+++ b/src/frontend/components/message-input.tsx
@@ -9,14 +9,19 @@ import { useIsMobileUser } from '../hooks';
 import { Button } from './button';
 
 type MessageInputProps = {
+  isInputExpanded?: boolean;
   onSendMessage: (content: string, author: string | null) => void;
+  toggleInputExpand?: () => void;
 };
 
-const MessageInput = ({ onSendMessage }: MessageInputProps) => {
+const MessageInput = ({
+  isInputExpanded,
+  onSendMessage,
+  toggleInputExpand,
+}: MessageInputProps) => {
   const isMobileUser = useIsMobileUser();
   const [author, setAuthor] = useState('');
   const [message, setMessage] = useState('');
-  const [isExpanded, setIsExpanded] = useState(true);
 
   const handleSubmit = () => {
     if (!message.trim()) return;
@@ -53,18 +58,20 @@ const MessageInput = ({ onSendMessage }: MessageInputProps) => {
             margin: '0 1px',
             maxWidth: 'calc(100vw - 2px)',
             border: `1px solid ${MAIN.BLUE}`,
+            transition: 'height 0.3s ease-in-out',
+            height: isInputExpanded ? '312px' : '80px',
           },
         }}
       >
         <MessageInputs
           author={author}
           message={message}
-          isExpanded={isExpanded}
+          isExpanded={isInputExpanded}
           handleSubmit={handleSubmit}
           handleKeyPress={handleKeyPress}
           onAuthorChange={onAuthorChange}
           onMessageChange={onMessageChange}
-          toggleExpand={() => setIsExpanded((prev) => !prev)}
+          toggleExpand={toggleInputExpand}
         />
       </Drawer>
     );
@@ -79,17 +86,19 @@ const MessageInput = ({ onSendMessage }: MessageInputProps) => {
         marginTop: '16px',
         width: '100%',
         justifySelf: 'end',
+        transition: 'height 0.3s ease-in-out',
+        height: isInputExpanded ? '312px' : '80px',
       })}
     >
       <MessageInputs
         author={author}
         message={message}
-        isExpanded={isExpanded}
+        isExpanded={isInputExpanded}
         handleSubmit={handleSubmit}
         handleKeyPress={handleKeyPress}
         onAuthorChange={onAuthorChange}
         onMessageChange={onMessageChange}
-        toggleExpand={() => setIsExpanded((prev) => !prev)}
+        toggleExpand={toggleInputExpand}
       />
     </Stack>
   );

--- a/src/frontend/components/message-list.tsx
+++ b/src/frontend/components/message-list.tsx
@@ -1,14 +1,29 @@
+import { useMemo } from 'react';
+
 import { Person2Outlined } from '@mui/icons-material';
 import { Stack, Typography } from '@mui/material';
 import { styled } from '@mui/system';
 import { BACKGROUND, MAIN } from 'src/constants/colors';
 import { SavedMessage } from 'src/constants/types';
 
+import { useIsMobileUser } from '../hooks';
+
 type MessageListProps = {
   messages: SavedMessage[];
+  isInputExpanded: boolean;
 };
 
-const MessageList = ({ messages }: MessageListProps) => {
+const MessageList = ({ messages, isInputExpanded }: MessageListProps) => {
+  const isMobileUser = useIsMobileUser();
+
+  const maxHeight = useMemo(() => {
+    if (isMobileUser) {
+      return isInputExpanded ? 'calc(100vh - 422px)' : 'calc(100vh - 190px)';
+    }
+
+    return isInputExpanded ? 'calc(100vh - 453px)' : 'calc(100vh - 220px)';
+  }, [isMobileUser, isInputExpanded]);
+
   if (messages.length === 0) {
     return (
       <Card marginTop="16px">
@@ -27,7 +42,7 @@ const MessageList = ({ messages }: MessageListProps) => {
   }
 
   return (
-    <ScrollableContainer marginTop="16px">
+    <ScrollableContainer marginTop="16px" height={maxHeight}>
       {messages.map((message) => (
         <Message key={message.id} message={message} />
       ))}
@@ -86,7 +101,7 @@ const Card = styled(Stack)(({ theme }) => ({
 }));
 
 const ScrollableContainer = styled(Stack)({
-  maxHeight: 'calc(100vh - 200px)',
+  transition: 'height 0.3s ease-in-out',
   borderRadius: '8px',
   overflowY: 'auto',
   paddingRight: '8px',

--- a/src/frontend/pages/room.tsx
+++ b/src/frontend/pages/room.tsx
@@ -12,6 +12,7 @@ import {
   MessageList,
   ShareRoomModal,
 } from '../components';
+import { useIsMobileUser } from '../hooks';
 
 export type RoomProps = {
   isLoading?: boolean;
@@ -29,7 +30,9 @@ const Room = ({
   sendMessage,
 }: RoomProps) => {
   const router = useRouter();
+  const isMobileUser = useIsMobileUser();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isInputExpanded, setIsInputExpanded] = useState(true);
 
   if (isLoading || !roomName)
     return (
@@ -51,7 +54,7 @@ const Room = ({
       sx={{
         height: '100vh',
         width: '100vw',
-        padding: '32px 15%',
+        padding: `32px ${isMobileUser ? '16px' : ' 15%'}`,
         backgroundColor: BACKGROUND.BLUE,
         justifyContent: 'space-between',
       }}
@@ -95,9 +98,13 @@ const Room = ({
             />
           </Stack>
         </Stack>
-        <MessageList messages={messages} />
+        <MessageList messages={messages} isInputExpanded={isInputExpanded} />
       </Stack>
-      <MessageInput onSendMessage={sendMessage} />
+      <MessageInput
+        onSendMessage={sendMessage}
+        isInputExpanded={isInputExpanded}
+        toggleInputExpand={() => setIsInputExpanded((prev) => !prev)}
+      />
       <ShareRoomModal
         roomId={roomId}
         isOpen={isModalOpen}


### PR DESCRIPTION
This pull request introduces enhancements to the `MessageInput`, `MessageList`, and `Room` components to support a collapsible message input feature and improve responsiveness for mobile users. The changes include adding new props, adjusting styles dynamically based on the input's state, and ensuring proper integration between components.

### Enhancements to `MessageInput` Component:

* Added `isInputExpanded` and `toggleInputExpand` props to manage the collapsible state of the input. Updated styles to adjust the height dynamically and added a smooth transition effect. (`src/frontend/components/message-input.tsx`, [[1]](diffhunk://#diff-5d2451559d284a4bab9cac211f1255a2c67e3fffd70bebc57035586850bec072R12-L19) [[2]](diffhunk://#diff-5d2451559d284a4bab9cac211f1255a2c67e3fffd70bebc57035586850bec072R61-R74) [[3]](diffhunk://#diff-5d2451559d284a4bab9cac211f1255a2c67e3fffd70bebc57035586850bec072R89-R101)

### Enhancements to `MessageList` Component:

* Added `isInputExpanded` prop to dynamically calculate and set the height of the message list based on the input's state and device type. Integrated `useMemo` for optimized height calculation and added a transition effect for smooth resizing. (`src/frontend/components/message-list.tsx`, [[1]](diffhunk://#diff-65ca331652307d693a473369f07f7b968cd82e4bf8783d5c1c0a632415400dcdR1-R26) [[2]](diffhunk://#diff-65ca331652307d693a473369f07f7b968cd82e4bf8783d5c1c0a632415400dcdL30-R45) [[3]](diffhunk://#diff-65ca331652307d693a473369f07f7b968cd82e4bf8783d5c1c0a632415400dcdL89-R104)

### Updates to `Room` Component:

* Introduced `isInputExpanded` state and integrated it with both `MessageInput` and `MessageList` components. Adjusted padding for mobile responsiveness using `useIsMobileUser`. (`src/frontend/pages/room.tsx`, [[1]](diffhunk://#diff-d618f62a0cf389b6061123dc6d71ca94265f0059d3c418c369179ee9b7d8224cR15) [[2]](diffhunk://#diff-d618f62a0cf389b6061123dc6d71ca94265f0059d3c418c369179ee9b7d8224cR33-R35) [[3]](diffhunk://#diff-d618f62a0cf389b6061123dc6d71ca94265f0059d3c418c369179ee9b7d8224cL54-R57) [[4]](diffhunk://#diff-d618f62a0cf389b6061123dc6d71ca94265f0059d3c418c369179ee9b7d8224cL98-R107)